### PR TITLE
Upate CI Actions Versions and Permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   publish_tester:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6.1.0
         with:
-          go-version: 1.17.x
+          go-version: 1.25.5
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,18 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6.1.0
         with:
-          go-version: 1.17.x
+          go-version: 1.25.5
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.13'
 
-      - run: make test
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
Reference:[Scroll down to `contents`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax?utm_source=chatgpt.com#permissions)

- Add Permissions for Publishing release
- Update CI actions versions to those used in claude code tester

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: CI workflows updated for publishing and testing.
> 
> - Grants `permissions: contents: write` in `publish.yml` to enable releases
> - Upgrades actions in both `publish.yml` and `test.yml`: `actions/checkout@v4`, `actions/setup-go@v6.1.0`, `actions/setup-python@v5`
> - Bumps runtime versions: Go to `1.25.5` and Python to `3.13`
> - Minor step cleanup: explicit "Run tests" step name in `test.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09ca0562766cc7eecb4307ce6eb13a79e13b1995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->