### PR TITLE
Add fixture regeneration workflow

### DIFF
--- a/.github/workflows/record_fixtures.yml
+++ b/.github/workflows/record_fixtures.yml
@@ -1,0 +1,64 @@
+name: Trigger Fixture Regeneration
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  trigger_pipeline:
+    if: github.event.label.name == 'regenerate-fixtures'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          lfs: true
+          token: ${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.1.0
+        with:
+          go-version: 1.25.5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # TODO: Add course-specific software/toolchain installation here
+
+      - uses: actions-ecosystem/action-create-comment@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Triggered a [Github Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) job to update fixtures.
+
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: regenerate-fixtures
+
+      - name: Setup git config
+        run: |
+          git config --global user.email "eddie@codecrafters.io"
+          git config --global user.name "Eddie"
+          git remote set-url origin https://${{ github.actor }}:${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+
+      - name: Regenerate Fixtures
+        run: CODECRAFTERS_RECORD_FIXTURES=true make test
+
+      - name: Update Fixtures
+        run: |
+          git fetch origin ${{ github.head_ref }}
+          git checkout ${{ github.head_ref }}
+          git add .
+          if ! git diff --cached --quiet; then
+            git commit -m "CI: Add regenerated fixtures"
+            git push
+          fi

--- a/.github/workflows/record_fixtures.yml
+++ b/.github/workflows/record_fixtures.yml
@@ -54,10 +54,12 @@ jobs:
         run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          git fetch origin ${{ github.head_ref }}
-          git checkout ${{ github.head_ref }}
-          git add .
+          git fetch origin "$BRANCH_NAME"
+          git checkout "$BRANCH_NAME"
+          git add internal/test_helpers/fixtures/
           if ! git diff --cached --quiet; then
             git commit -m "CI: Add regenerated fixtures"
             git push

--- a/.github/workflows/record_fixtures.yml
+++ b/.github/workflows/record_fixtures.yml
@@ -1,58 +1,18 @@
 name: Trigger Fixture Regeneration
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request:
     types:
       - labeled
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  trigger_pipeline:
+  regenerate_fixtures:
     if: github.event.label.name == 'regenerate-fixtures'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          lfs: true
-          token: ${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}
-
-      - name: Set up Go
-        uses: actions/setup-go@v6.1.0
-        with:
-          go-version: 1.25.5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      # TODO: Add course-specific software/toolchain installation here
-
-      - uses: actions-ecosystem/action-create-comment@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Triggered a [Github Actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) job to update fixtures.
-
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: regenerate-fixtures
-
-      - name: Setup git config
-        run: |
-          git config --global user.email "eddie@codecrafters.io"
-          git config --global user.name "Eddie"
-          git remote set-url origin https://${{ github.actor }}:${{ secrets.TESTER_FIXTURE_GENERATION_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-
-      - name: Regenerate Fixtures
-        run: CODECRAFTERS_RECORD_FIXTURES=true make test
-
-      - name: Update Fixtures
-        run: |
-          git add . && git diff --cached --quiet || (git commit -m "CI: Add regenerated fixtures" && git push)
+    uses: codecrafters-io/tester-utils/.github/workflows/fixtures.yml@master
+    with:
+      tester_repo: "<tester-slug>" # TODO: Fill in repo name here e.g "redis-tester"
+    secrets: inherit

--- a/.github/workflows/record_fixtures.yml
+++ b/.github/workflows/record_fixtures.yml
@@ -54,13 +54,5 @@ jobs:
         run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          git fetch origin "$BRANCH_NAME"
-          git checkout "$BRANCH_NAME"
-          git add internal/test_helpers/fixtures/
-          if ! git diff --cached --quiet; then
-            git commit -m "CI: Add regenerated fixtures"
-            git push
-          fi
+          git add . && git diff --cached --quiet || (git commit -m "CI: Add regenerated fixtures" && git push)

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,8 @@ copy_course_file:
 
 update_tester_utils:
 	go get -u github.com/codecrafters-io/tester-utils
+
+setup:
+	echo "Setting up prerequisites"
+	## TODO: Insert prerequisites: These will be used by record-fixtures workflow
+	echo "Setup complete!"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a GitHub Actions workflow that runs with `contents`/`pull-requests` write permissions and inherits secrets, so misconfiguration or label misuse could trigger unintended writes.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/record_fixtures.yml`) that triggers on PR label events and, when the `regenerate-fixtures` label is applied, runs the shared `tester-utils` `fixtures.yml` workflow with repo write permissions and inherited secrets.
> 
> Extends the `Makefile` with a placeholder `setup` target intended to install prerequisites for the fixture-recording workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e32a5de3e59735bb07a98fb5900ad629bc171b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->