### PR TITLE
Workflow fixture commit security

### DIFF
--- a/.github/workflows/record_fixtures.yml
+++ b/.github/workflows/record_fixtures.yml
@@ -54,10 +54,12 @@ jobs:
         run: CODECRAFTERS_RECORD_FIXTURES=true make test
 
       - name: Update Fixtures
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          git fetch origin ${{ github.head_ref }}
-          git checkout ${{ github.head_ref }}
-          git add .
+          git fetch origin "$BRANCH_NAME"
+          git checkout "$BRANCH_NAME"
+          git add internal/test_helpers/fixtures/
           if ! git diff --cached --quiet; then
             git commit -m "CI: Add regenerated fixtures"
             git push


### PR DESCRIPTION
Fixes a logic bug by targeting only fixture files for commit and a security bug by quoting the branch name in shell commands.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; reduces chance of unintended file commits and mitigates shell injection issues when using untrusted branch names.
> 
> **Overview**
> The `record_fixtures.yml` workflow now stores the PR branch in `BRANCH_NAME`, uses it with proper quoting in `git fetch/checkout`, and stages only `internal/test_helpers/fixtures/` instead of `git add .`.
> 
> This prevents accidental commits of unrelated files during fixture regeneration and hardens the job against unsafe branch-name shell expansion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c93dc84b197e6c95272b5f8a4ab6d41ca74a3d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->